### PR TITLE
Add extensive parser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# isoParser
+# ISO Parser
+
+This project provides a simple ISO 8583 message parser implemented in Go. It exposes a small WebSocket server that accepts incoming hexadecimal ISO messages and returns a JSON structure describing selected data elements.
+
+## Example
+
+```
+006330343330902000000020800000000000040000003030303030303031303030303132333435364143515549524552204E414D452043495459204E414D4520434155534120202020202020202020383430313631323334353637383930313233343536
+```
+
+Parsing the above message produces the following JSON:
+
+```
+{
+  "message_type": "Reversal Advice Response",
+  "amount": "000000010000",
+  "card_reference_id": "1234567890123456",
+  "currency": "840",
+  "description": "ACQUIRER NAME CITY NAME CAUSA"
+}
+```
+
+## Running the Server
+
+Make sure you have Go installed (1.20 or newer). Start the WebSocket server with:
+
+```bash
+go run .
+```
+
+The server listens on `localhost:8080` and exposes a WebSocket endpoint at `/ws`. Send a hex string as the payload of a WebSocket text frame to receive the parsed JSON message.
+
+## Running Tests
+
+Execute all unit tests with:
+
+```bash
+go test ./...
+```
+
+The tests include several examples extracted from `input.md` to validate parsing of fixed and variable length fields.
+

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,9 +1,15 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
 
 const sample0430 = "006330343330902000000020800000000000040000003030303030303031303030303132333435364143515549524552204E414D452043495459204E414D452043415553412020202020202020202020383430313631323334353637383930313233343536"
 
+// Sample 0430 message taken from input.md lines around 14018
 func TestParseISO8583(t *testing.T) {
 	msg, err := parseISO8583(sample0430)
 	if err != nil {
@@ -23,5 +29,74 @@ func TestParseISO8583(t *testing.T) {
 	}
 	if msg.Description != "ACQUIRER NAME CITY NAME CAUSA" {
 		t.Errorf("unexpected description: %q", msg.Description)
+	}
+}
+
+// The following examples use values from input.md (e.g. lines 13361-13367)
+func TestParseISO8583UnknownField(t *testing.T) {
+	// This message is based on the 0800 sample but padded to even length
+	_, err := parseISO8583("006708008220000008000000040000000000000004091115300880019099160880010081")
+	if err == nil || !strings.Contains(err.Error(), "spec for field 21 missing") {
+		// just check an error occurred since field 21 is not defined
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	}
+}
+
+func TestParseISO8583OddLength(t *testing.T) {
+	// Hex string from input.md line 13361 has odd length
+	_, err := parseISO8583("00670800822000000800000004000000000000000409111530088001909916088001081")
+	if err == nil {
+		t.Fatal("expected error for odd length hex string")
+	}
+}
+
+func TestParseISO8583TooShort(t *testing.T) {
+	_, err := parseISO8583("0010")
+	if err == nil {
+		t.Fatal("expected error for short message")
+	}
+}
+
+func TestParseFieldFixed(t *testing.T) {
+	val, n, err := parseField([]byte("61002000rest"), FieldSpec{LengthType: "fixed", Length: 8})
+	if err != nil || val != "61002000" || n != 8 {
+		t.Fatalf("unexpected result %q %d %v", val, n, err)
+	}
+}
+
+func TestParseFieldFixedShort(t *testing.T) {
+	_, _, err := parseField([]byte("6100"), FieldSpec{LengthType: "fixed", Length: 8})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestParseFieldLLVar(t *testing.T) {
+	val, n, err := parseField([]byte("15100194868736564rest"), FieldSpec{LengthType: "llvar", Length: 19})
+	if err != nil || val != "100194868736564" || n != 17 {
+		t.Fatalf("unexpected result %q %d %v", val, n, err)
+	}
+}
+
+func TestParseFieldLLVarShort(t *testing.T) {
+	_, _, err := parseField([]byte("05abc"), FieldSpec{LengthType: "llvar", Length: 19})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestParseFieldLLVarInvalid(t *testing.T) {
+	_, _, err := parseField([]byte("20"+strings.Repeat("a", 20)), FieldSpec{LengthType: "llvar", Length: 19})
+	if err == nil {
+		t.Fatal("expected invalid llvar length error")
+	}
+}
+
+func TestParseFieldLLLVar(t *testing.T) {
+	val, n, err := parseField([]byte("006VISA16"), FieldSpec{LengthType: "lllvar", Length: 120})
+	if err != nil || val != "VISA16" || n != 9 {
+		t.Fatalf("unexpected result %q %d %v", val, n, err)
 	}
 }


### PR DESCRIPTION
## Summary
- expand `parser_test.go` with a variety of additional tests
- include examples from the ISO 8583 spec in `input.md`
- flesh out `README` with project details, usage examples and test instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e85edd9ac83238378fd0881dcab56