### PR TITLE
Extend ISO parsing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,45 @@ Parsing the above message produces the following JSON:
 
 ```
 {
+  "transaction_code": "0430",
   "message_type": "Reversal Advice Response",
   "amount": "000000010000",
   "card_reference_id": "1234567890123456",
   "currency": "840",
+  "currency_iso3": "USD",
   "description": "ACQUIRER NAME CITY NAME CAUSA"
 }
 ```
+
+## Transaction Codes
+
+| Code | Type |
+|------|------|
+| 0100 | Authorization Request |
+| 0110 | Authorization Response |
+| 0120 | Authorization Advice |
+| 0130 | Authorization Advice Response |
+| 0200 | Financial Transaction Request |
+| 0210 | Financial Transaction Response |
+| 0220 | Financial Transaction Advice |
+| 0230 | Financial Transaction Advice Response |
+| 0302 | File Update Request |
+| 0312 | File Update Response |
+| 0420 | Reversal Advice |
+| 0430 | Reversal Advice Response |
+| 0600 | Administrative Request |
+| 0620 | Administrative Advice |
+| 0630 | Administrative Advice Response |
+| 0800 | Network Management Request |
+| 0810 | Network Management Response |
+
+## Currency Codes
+
+| Numeric | ISO-3 |
+|---------|------|
+| 840     | USD |
+| 978     | EUR |
+| 826     | GBP |
 
 ## Running the Server
 

--- a/main.go
+++ b/main.go
@@ -69,11 +69,25 @@ var mtiDescriptions = map[string]string{
 	"0810": "Network Management Response",
 }
 
+// currencyISO3 maps numeric ISO 4217 currency codes to their alphabetic
+// counterparts. Only a very small subset is required for the examples and tests
+// contained in this repository.
+var currencyISO3 = map[string]string{
+	"840": "USD",
+	"978": "EUR",
+	"826": "GBP",
+}
+
+// ISOMessage represents a subset of the parsed ISO8583 fields. In addition to
+// the original fields this structure now exposes the numeric transaction code
+// (MTI), as well as the alphabetic ISO‑3 currency code.
 type ISOMessage struct {
+	TransactionCode string `json:"transaction_code"`
 	MessageType     string `json:"message_type"`
 	Amount          string `json:"amount"`
 	CardReferenceID string `json:"card_reference_id"`
 	Currency        string `json:"currency"`
+	CurrencyISO3    string `json:"currency_iso3"`
 	Description     string `json:"description"`
 }
 
@@ -163,6 +177,7 @@ func parseISO8583(hexMsg string) (ISOMessage, error) {
 		fields[num] = val
 		pos += read
 	}
+	result.TransactionCode = mti
 	result.MessageType = mtiDescriptions[mti]
 	if v, ok := fields[4]; ok {
 		result.Amount = v
@@ -172,6 +187,9 @@ func parseISO8583(hexMsg string) (ISOMessage, error) {
 	}
 	if v, ok := fields[49]; ok {
 		result.Currency = v
+		if alpha, ok := currencyISO3[v]; ok {
+			result.CurrencyISO3 = alpha
+		}
 	}
 	if v, ok := fields[43]; ok {
 		result.Description = strings.TrimSpace(v)

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,6 +15,9 @@ func TestParseISO8583(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseISO8583 returned error: %v", err)
 	}
+	if msg.TransactionCode != "0430" {
+		t.Errorf("unexpected transaction code: %q", msg.TransactionCode)
+	}
 	if msg.MessageType != "Reversal Advice Response" {
 		t.Errorf("unexpected message type: %q", msg.MessageType)
 	}
@@ -26,6 +29,9 @@ func TestParseISO8583(t *testing.T) {
 	}
 	if msg.Currency != "840" {
 		t.Errorf("unexpected currency: %q", msg.Currency)
+	}
+	if msg.CurrencyISO3 != "USD" {
+		t.Errorf("unexpected currency ISO3: %q", msg.CurrencyISO3)
 	}
 	if msg.Description != "ACQUIRER NAME CITY NAME CAUSA" {
 		t.Errorf("unexpected description: %q", msg.Description)


### PR DESCRIPTION
## Summary
- include transaction code in ISOMessage output
- include alphabetic ISO3 currency code
- document new fields in README
- verify new fields in unit tests
- add transaction code and currency tables to README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8b2b2618832395e8a0fb1606bd55