### PR TITLE
Add parser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # isoParser
+
+This repository includes a simple ISO 8583 parser implemented in C# targeting .NET 8.0.
+
+The parser reads a hexadecimal representation of an ISO 8583 message and outputs the message type and present data elements.
+
+## Building
+
+The project is contained in the `src` folder. To build or run the parser you need the .NET 8 SDK installed.
+
+```
+dotnet build src/IsoParser.sln
+```
+
+## Usage
+
+Provide a hex string as an argument:
+
+```
+dotnet run --project src/IsoParserConsole -- <hex string>
+```
+
+The program will print the MTI and each parsed field.

--- a/src/IsoParser.sln
+++ b/src/IsoParser.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IsoParserConsole", "IsoParserConsole/IsoParserConsole.csproj", "{DEADBEEF-0000-0000-0000-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IsoParserTests", "IsoParserTests/IsoParserTests.csproj", "{DEADBEEF-0000-0000-0000-000000000002}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {DEADBEEF-0000-0000-0000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DEADBEEF-0000-0000-0000-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/src/IsoParserConsole/IsoParserConsole.csproj
+++ b/src/IsoParserConsole/IsoParserConsole.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/IsoParserConsole/Program.cs
+++ b/src/IsoParserConsole/Program.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace IsoParserConsole;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.WriteLine("Usage: IsoParserConsole <hex message>");
+            return;
+        }
+
+        string hex = args[0];
+        var parser = new Iso8583Parser();
+        var message = parser.Parse(hex);
+        Console.WriteLine($"MTI: {message.Mti}");
+        foreach (var field in message.Fields)
+        {
+            Console.WriteLine($"DE-{field.Key}: {field.Value}");
+        }
+    }
+}
+
+public record IsoMessage(string Mti, Dictionary<int, string> Fields);
+
+public class Iso8583Parser
+{
+    private readonly Dictionary<int, FieldDef> _defs = new()
+    {
+        {2, new FieldDef(FieldType.LLVAR)},
+        {3, new FieldDef(6)},
+        {4, new FieldDef(12)},
+        {6, new FieldDef(12)},
+        {7, new FieldDef(10)},
+        {10, new FieldDef(8)},
+        {11, new FieldDef(6)},
+        {12, new FieldDef(6)},
+        {13, new FieldDef(4)},
+        {15, new FieldDef(4)},
+        {18, new FieldDef(4)},
+        {22, new FieldDef(3)},
+        {25, new FieldDef(2)},
+        {28, new FieldDef(9)},
+        {32, new FieldDef(FieldType.LLVAR)},
+        {37, new FieldDef(12)},
+        {38, new FieldDef(6)},
+        {39, new FieldDef(2)},
+        {41, new FieldDef(8, FieldEncoding.Ascii)},
+        {42, new FieldDef(15, FieldEncoding.Ascii)},
+        {43, new FieldDef(40, FieldEncoding.Ascii)},
+        {49, new FieldDef(3)},
+        {51, new FieldDef(3)},
+        {54, new FieldDef(FieldType.LLVAR)},
+        {61, new FieldDef(FieldType.LLVAR)},
+        {63, new FieldDef(FieldType.LLVAR)},
+        {102, new FieldDef(FieldType.LLVAR)},
+        {111, new FieldDef(FieldType.LLLVAR)}
+    };
+
+    public IsoMessage Parse(string hex)
+    {
+        byte[] bytes = Convert.FromHexString(hex);
+        int index = 0;
+
+        // length prefix
+        index += 2; // two bytes length
+        string mti = ReadAscii(bytes, ref index, 4);
+
+        ulong primaryBitmap = ReadBitmap(bytes, ref index);
+        ulong? secondaryBitmap = null;
+        if ((primaryBitmap & (1UL << 63)) != 0)
+        {
+            secondaryBitmap = ReadBitmap(bytes, ref index);
+        }
+
+        var fields = new Dictionary<int, string>();
+        for (int bit = 2; bit <= 128; bit++)
+        {
+            bool present = bit <= 64
+                ? ((primaryBitmap >> (64 - bit)) & 1) == 1
+                : secondaryBitmap != null && (((secondaryBitmap.Value) >> (128 - bit)) & 1) == 1;
+
+            if (!present) continue;
+            if (!_defs.TryGetValue(bit, out var def))
+            {
+                throw new NotSupportedException($"Field {bit} not supported");
+            }
+            string value = def.Read(bytes, ref index);
+            fields[bit] = value;
+        }
+
+        return new IsoMessage(mti, fields);
+    }
+
+    static ulong ReadBitmap(byte[] bytes, ref int index)
+    {
+        ulong value = 0;
+        for (int i = 0; i < 8; i++)
+        {
+            value = (value << 8) | bytes[index++];
+        }
+        return value;
+    }
+
+    static string ReadAscii(byte[] bytes, ref int index, int length)
+    {
+        string s = System.Text.Encoding.ASCII.GetString(bytes, index, length);
+        index += length;
+        return s;
+    }
+}
+
+public enum FieldType
+{
+    Fixed,
+    LLVAR,
+    LLLVAR
+}
+
+public enum FieldEncoding
+{
+    Numeric,
+    Ascii
+}
+
+public class FieldDef
+{
+    public FieldType Type { get; }
+    public int Length { get; }
+    public FieldEncoding Encoding { get; }
+
+    public FieldDef(int length, FieldEncoding encoding = FieldEncoding.Numeric)
+    {
+        Type = FieldType.Fixed;
+        Length = length;
+        Encoding = encoding;
+    }
+
+    public FieldDef(FieldType type, FieldEncoding encoding = FieldEncoding.Numeric)
+    {
+        Type = type;
+        Encoding = encoding;
+    }
+
+    public string Read(byte[] bytes, ref int index)
+    {
+        int len = Length;
+        if (Type == FieldType.LLVAR)
+        {
+            len = int.Parse(ReadAscii(bytes, ref index, 2), CultureInfo.InvariantCulture);
+        }
+        else if (Type == FieldType.LLLVAR)
+        {
+            len = int.Parse(ReadAscii(bytes, ref index, 3), CultureInfo.InvariantCulture);
+        }
+
+        string value = Encoding == FieldEncoding.Ascii
+            ? ReadAscii(bytes, ref index, len)
+            : System.Text.Encoding.ASCII.GetString(bytes, index, len);
+        index += len;
+        return value;
+    }
+
+    static string ReadAscii(byte[] bytes, ref int index, int length)
+    {
+        string s = System.Text.Encoding.ASCII.GetString(bytes, index, length);
+        index += length;
+        return s;
+    }
+}

--- a/src/IsoParserTests/IsoParserTests.csproj
+++ b/src/IsoParserTests/IsoParserTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IsoParserConsole\IsoParserConsole.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/IsoParserTests/ParserTests.cs
+++ b/src/IsoParserTests/ParserTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using IsoParserConsole;
+using Xunit;
+
+public class ParserTests
+{
+    public static IEnumerable<object[]> SingleFieldCases => new List<object[]>
+    {
+        new object[]{2, "100194868736564"},
+        new object[]{3, "000000"},
+        new object[]{4, "000000050000"},
+        new object[]{6, "000000050100"},
+        new object[]{7, "0122132918"},
+        new object[]{10, "61002000"},
+        new object[]{11, "016372"},
+        new object[]{12, "182918"},
+        new object[]{13, "0122"},
+        new object[]{15, "0122"},
+        new object[]{18, "5541"},
+        new object[]{22, "902"},
+        new object[]{25, "00"},
+        new object[]{28, "D00000000"},
+        new object[]{32, "000000"},
+        new object[]{37, "802213016372"},
+        new object[]{41, "TERMID01"},
+        new object[]{42, "CARD ACCEPTOR"},
+        new object[]{43, "ACQUIRER NAME CITY NAME CAUSA".PadRight(40)},
+        new object[]{49, "840"}
+    };
+
+    [Theory]
+    [MemberData(nameof(SingleFieldCases))]
+    public void ParseSingleField(int field, string value)
+    {
+        string hex = IsoMessageBuilder.Build("0200", (field, value));
+        var parser = new Iso8583Parser();
+        var msg = parser.Parse(hex);
+        Assert.Equal("0200", msg.Mti);
+        Assert.Single(msg.Fields);
+        Assert.Equal(value, msg.Fields[field]);
+    }
+
+    [Fact]
+    public void ParseExampleFromSpec()
+    {
+        string hex = IsoMessageBuilder.Build("0100",
+            (2, "100194868736564"),
+            (3, "000000"),
+            (4, "000000050000"),
+            (6, "000000050100"),
+            (7, "0122132918"),
+            (10, "61002000"),
+            (11, "016372"),
+            (12, "182918"),
+            (13, "0122"),
+            (15, "0122"),
+            (18, "5541"),
+            (22, "902"),
+            (25, "00"),
+            (28, "D00000000"),
+            (32, "000000"),
+            (37, "802213016372"),
+            (41, "TERMID01"),
+            (42, "CARD ACCEPTOR"),
+            (43, "ACQUIRER NAME CITY NAME CAUSA"),
+            (49, "840"),
+            (51, "840"),
+            (54, "0072840D000000000100"),
+            (61, "0000000004020000"),
+            (63, "0002 123456123456123 0 VISA"),
+            (102, "100194868736564"),
+            (111, " 123456123456123 00 000000 0000000000 000000000000 0000000000 00020000000000000000 00 0768892")
+        );
+
+        var parser = new Iso8583Parser();
+        var msg = parser.Parse(hex);
+
+        Assert.Equal("0100", msg.Mti);
+        Assert.Equal("100194868736564", msg.Fields[2]);
+        Assert.Equal("000000050000", msg.Fields[4]);
+        Assert.Equal("802213016372", msg.Fields[37]);
+        Assert.Equal("TERMID01", msg.Fields[41]);
+        Assert.Equal("840", msg.Fields[51]);
+        Assert.Equal("0002 123456123456123 0 VISA", msg.Fields[63]);
+    }
+}
+
+static class IsoMessageBuilder
+{
+    private static readonly Dictionary<int, FieldDef> Defs = new()
+    {
+        {2, new FieldDef(FieldType.LLVAR)},
+        {3, new FieldDef(6)},
+        {4, new FieldDef(12)},
+        {6, new FieldDef(12)},
+        {7, new FieldDef(10)},
+        {10, new FieldDef(8)},
+        {11, new FieldDef(6)},
+        {12, new FieldDef(6)},
+        {13, new FieldDef(4)},
+        {15, new FieldDef(4)},
+        {18, new FieldDef(4)},
+        {22, new FieldDef(3)},
+        {25, new FieldDef(2)},
+        {28, new FieldDef(9)},
+        {32, new FieldDef(FieldType.LLVAR)},
+        {37, new FieldDef(12)},
+        {41, new FieldDef(8, FieldEncoding.Ascii)},
+        {42, new FieldDef(15, FieldEncoding.Ascii)},
+        {43, new FieldDef(40, FieldEncoding.Ascii)},
+        {49, new FieldDef(3)},
+        {51, new FieldDef(3)},
+        {54, new FieldDef(FieldType.LLVAR)},
+        {61, new FieldDef(FieldType.LLVAR)},
+        {63, new FieldDef(FieldType.LLVAR)},
+        {102, new FieldDef(FieldType.LLVAR)},
+        {111, new FieldDef(FieldType.LLLVAR)}
+    };
+
+    public static string Build(string mti, params (int field, string value)[] fields)
+    {
+        var ordered = fields.OrderBy(f => f.field).ToList();
+        bool[] primary = new bool[64];
+        bool[] secondary = new bool[64];
+        bool needSecondary = ordered.Any(f => f.field > 64);
+        foreach (var f in ordered)
+        {
+            if (f.field <= 64) primary[f.field - 1] = true; else secondary[f.field - 65] = true;
+        }
+        if (needSecondary) primary[0] = true;
+        var bytes = new List<byte>();
+        bytes.AddRange(Encoding.ASCII.GetBytes(mti));
+        bytes.AddRange(ToBitmap(primary));
+        if (needSecondary) bytes.AddRange(ToBitmap(secondary));
+        foreach (var f in ordered)
+        {
+            var def = Defs[f.field];
+            bytes.AddRange(Encode(def, f.value));
+        }
+        ushort len = (ushort)bytes.Count;
+        bytes.Insert(0, (byte)(len >> 8));
+        bytes.Insert(1, (byte)(len & 0xFF));
+        return Convert.ToHexString(bytes.ToArray());
+    }
+
+    private static byte[] ToBitmap(bool[] bits)
+    {
+        byte[] data = new byte[8];
+        for (int i = 0; i < 64; i++)
+            if (bits[i]) data[i / 8] |= (byte)(1 << (7 - (i % 8)));
+        return data;
+    }
+
+    private static byte[] Encode(FieldDef def, string value)
+    {
+        var list = new List<byte>();
+        if (def.Type == FieldType.LLVAR) list.AddRange(Encoding.ASCII.GetBytes(value.Length.ToString("D2")));
+        else if (def.Type == FieldType.LLLVAR) list.AddRange(Encoding.ASCII.GetBytes(value.Length.ToString("D3")));
+        list.AddRange(Encoding.ASCII.GetBytes(value));
+        return list.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary
- expose ISO parser classes publicly
- add xUnit test project with 20 single-field tests
- include test project in solution
- extend test helper definitions
- add full message parse test based on spec example

## Testing
- `dotnet test src/IsoParser.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8e147b5c832395dda72094ad08e0